### PR TITLE
fixed right associativity for arrows in parser

### DIFF
--- a/Parser.py
+++ b/Parser.py
@@ -100,7 +100,7 @@ def expr(tokens):
     lhs = or_expr(tokens)
     while tokens[0].ttype == TType.TARROW:
         tokens.pop(0)
-        rhs = or_expr(tokens)
+        rhs = expr(tokens)
         lhs = Arrow(lhs, rhs)
     if tokens[0].ttype not in follow:
         raise ParseException(tokens[0].pos,follow,tokens[0].val)


### PR DESCRIPTION
As it was, the expr function looped until there were no arrows left, and the last arrow in the tokens list was returned as the root of the tree. This is opposite of how arrows should associate, so I changed it to a recursive call setting the rhs to the result of calling expr on the remaining tokens. This preserves the first arrow as the root, correcting the associativity.